### PR TITLE
WIP: 47-gui-for-parameter-configuration

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -30,6 +30,7 @@ Content
    usr/getting_started.rst
    usr/concepts.rst
    usr/glyph_remote.rst
+   usr/gui.rst
 
    Publications <usr/publications.rst>
    About <usr/about.rst>

--- a/doc/source/usr/gui.rst
+++ b/doc/source/usr/gui.rst
@@ -1,0 +1,94 @@
+
+Glyph remote - GUI
+==================
+
+
+Install
+'''''''''''''''''''''''''
+
+Glyph comes with an optional GUI to use the ``glyph-remote`` script with mor convenience.
+
+The GUI uses the package ``wxPython``, in order to install glyph all the prerequisites of wxPython must be installed.
+
+**For Ubuntu those are:**
+
+- dpkg-dev
+- build-essential
+- python3.5-dev # minimum version to use glyph
+- libjpeg-dev
+- libtiff-dev
+- libsdl1.2-dev
+- libgstreamer-plugins-base0.10-dev
+- libnotify-dev
+- freeglut3
+- freeglut3-dev
+- libsm-dev
+- libgtk-3-dev
+- libwebkitgtk-3.0-dev # or libwebkit2gtk-4.0-dev if available
+- libxtst-dev
+
+For further questions see the developers github `README.md <https://github.com/wxWidgets/Phoenix/blob/master/README.rst#prerequisites>`_
+and `Website <https://wxpython.org/>`_.
+
+**Note:**
+If you consider to use a conda envrionment:
+``conda install wxpython`` should do the trick
+
+Manual Gooey installtion
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since up-to-date (28.08.2018) the neccesarry changes to the used graphic library Gooey are not part of the master branch,
+it might be neccessary to install Gooey by hand from the repo `https://github.com/Magnati/Gooey <https://github.com/Magnati/Gooey>`_ in three steps.
+
+- ``git clone git@github.com:Magnati/Gooey.git``
+- ``cd Gooey``
+- ``python setup.py install``
+
+Installation with pip installtion
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To install glyph including the gui option use the following command:
+
+.. code-block::
+    python pip install pyglyph[gui]``
+
+To start the script with the gui just use the ``--gui`` parameter:
+
+.. code-block::
+    glyph-remote --gui
+
+Usage
+''''''
+
+Within the GUI there are the following tabs:
+
+- Optional Arguments,
+- GP config
+- algorithm
+- breeding
+- assessment
+- break
+- condition
+- constraints
+
+If all primitves are set, click the Start-button to start the remoteserver.
+If you start another shell and cd to
+``/glyph/examples/remote/``
+you may start the example experiment ``python experiment.py``.
+
+In the **GP config** tab you may specify a `config.yaml` to set All parameters from the tabs
+
+- algorithm
+- breeding
+- assessment
+- break condition
+- constraints
+
+As well as the used primitives. An example can be found in
+
+``/glyph/examples/remote/experiment.yaml``
+
+For your own experiemnts the `experiment_dummy.py` is a good file to start.
+
+
+

--- a/glyph/application.py
+++ b/glyph/application.py
@@ -329,7 +329,7 @@ class AlgorithmFactory(AFactory):
                             default=0.5, help='crossover probability for mating (default: 0.5)')
         parser.add_argument('--mutation_prob', metavar='p', type=utils.argparse.unit_interval,
                             default=0.2, help='mutation probability (default: 0.2)')
-        parser.add_argument('--tournament_size', dest='tournament_size', metavar='n', type=utils.argparse.unit_interval,
+        parser.add_argument('--tournament_size', dest='tournament_size', metavar='n', type=utils.argparse.positive_int,
                             default=2, help='tournament size for tournament selection (default: 2)')
 
 

--- a/glyph/cli/glyph_remote.py
+++ b/glyph/cli/glyph_remote.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import random
+import sys
 from functools import partial
 from threading import Thread
 from time import sleep
@@ -34,6 +35,7 @@ from glyph.observer import ProgressObserver
 from glyph.utils.argparse import readable_file
 from glyph.utils.break_condition import break_condition
 from glyph.utils.logging import print_params
+from glyph.gui.glyph_gooey import get_gooey
 from queue import Queue
 from scipy.optimize._minimize import _minimize_neldermead as nelder_mead
 
@@ -113,8 +115,8 @@ class RemoteApp(glyph.application.Application):
         self.logger.debug("Saved checkpoint to {}".format(self.checkpoint_file))
 
 
-def get_parser():
-    parser = argparse.ArgumentParser(prog="glyph-remote")
+def get_parser(parser=None, gui=False):
+    parser = parser or argparse.ArgumentParser(prog="glyph-remote")
     parser.add_argument(
         "--port", type=int, default=5555, help="Port for the zeromq communication (default: 5555)"
     )
@@ -623,7 +625,11 @@ def make_callback(factories, args):
 
 
 def make_remote_app(callbacks=(), callback_factories=(), parser=None):
-    parser = parser or get_parser()
+    if parser is None:
+        if "--gui" in sys.argv:
+            parser = get_parser(parser=get_gooey(RemoteApp), gui=True)
+        else:
+            parser = get_parser()
     args = parser.parse_args()
     send, recv = connect(args.ip, args.port)
     workdir = os.path.dirname(os.path.abspath(args.checkpoint_file))

--- a/glyph/gui/__init__.py
+++ b/glyph/gui/__init__.py
@@ -1,0 +1,1 @@
+from . import glyph_gooey

--- a/glyph/gui/glyph_gooey.py
+++ b/glyph/gui/glyph_gooey.py
@@ -1,0 +1,64 @@
+import logging
+
+import gooey
+
+logger = logging.getLogger(__name__)
+
+gooey_in_use = False
+
+
+@gooey.Gooey(
+    auto_start=False,  # Skips the configuration all together and runs the program immediately
+    advanced=True,  # toggle whether to show advanced config or not
+    encoding="utf-8",  # Text encoding to use when displaying characters (default: 'utf-8')
+    language="english",  # Translations configurable via json
+    show_config=True,  # skip config screens all together
+    # target=executable_cmd,     # Explicitly set the subprocess executable arguments
+    # program_name='name',       # Defaults to script name
+    # program_description="",       # Defaults to ArgParse Description
+    default_size=(1200, 1000),  # starting size of the GUI
+    # required_cols=1,           # number of columns in the "Required" section NOTE:Deprecation notice: See Group Parameters for modern layout controls
+    # optional_cols=2,           # number of columbs in the "Optional" section NOTE:Deprecation notice: See Group Parameters for modern layout controls
+    dump_build_config=False,  # Dump the JSON Gooey uses to configure itself
+    load_build_config=None,  # Loads a JSON Gooey-generated configuration
+    monospace_display=False,  # Uses a mono-spaced font in the output screen
+    # image_dir=, 	       # Path to the directory in which Gooey should look for custom images/icons
+    # language_dir=,  	   # Path to the directory in which Gooey should look for custom languages files
+    disable_stop_button=False,  # Disable the Stop button when running
+    show_stop_warning=True,  # Displays a warning modal before allowing the user to force termination of your program
+    force_stop_is_error=True,  # Toggles whether an early termination by the shows the success or error screen
+    show_success_modal=True,  # Toggles whether or not to show a summary modal after a successful run
+    run_validators=True,  # Controls whether or not to have Gooey perform validation before calling your program
+    poll_external_updates=False,  # (Experimental!) When True, Gooey will call your code with a gooey-seed-ui CLI argument and use the response to fill out dynamic values in the UI (See: Using Dynamic Values)
+    return_to_config=False,  # When True, Gooey will return to the configuration settings window upon successful run
+    # progress_regex=, 	   # A text regex used to pattern match runtime progress information. See: Showing Progress for a detailed how-to
+    # progress_expr=, 	   # A python expression applied to any matches found via the progress_regex. See: Showing Progress for a detailed how-to
+    disable_progress_bar_animation=False,  # Disable the progress bar
+    navigation="SIDEBAR",  # Sets the "navigation" style of Gooey's top level window. Options: TABBED	SIDEBAR
+    tabbed_groups=True,
+    navigation_title="Actions",  # Controls the heading title above the SideBar's navigation pane. Defaults to: "Actions"
+    show_sidebar=False,  # Show/Hide the sidebar in when navigation mode == SIDEBAR
+    # body_bg_color, 	        # HEX value of the main Gooey window
+    # header_bg_color, 	        # HEX value of the header background
+    # header_height,             # height in pixels of the header
+    # header_show_title, 	    # Show/Hide the header title
+    # header_show_subtitle,      # Show/Hide the header subtitle
+    # footer_bg_color, 	        # HEX value of the Footer background
+    # sidebar_bg_color, 	        # HEX value of the Sidebar's background
+    # terminal_panel_color, 	    # HEX value of the terminal's panel
+    # terminal_font_color, 	    # HEX value of the font displayed in Gooey's terminal
+    # terminal_font_family, 	    # Name of the Font Family to use in the terminal
+    # terminal_font_weight,	    # Weight of the font (NORMAL
+    # terminal_font_size, 	    # Point size of the font displayed in the terminal
+    # error_color, 	            # HEX value of the text displayed when a validation error occurs
+)
+def get_gooey(RemoteApp):
+    global gooey_in_use
+    gooey_in_use = True
+    parser = gooey.GooeyParser(prog="glyph-remote-gui")
+    return parser
+
+
+def is_gooey_active():
+    global gooey_in_use
+    return gooey_in_use

--- a/glyph/utils/argparse.py
+++ b/glyph/utils/argparse.py
@@ -4,8 +4,11 @@
 """Collection of helper functions for arparse."""
 
 import argparse
+import logging
 import os
+import sys
 
+logger = logging.getLogger(__name__)
 
 def positive_int(string):
     """Check whether string is an integer greater than 0."""
@@ -62,3 +65,32 @@ def readable_file(string):
     except IOError:
         raise argparse.ArgumentTypeError("Must be a readable file path {}".format(path))
     return path
+
+def readable_yaml_file(string):
+    """Check weather file is a .yaml file and readable"""
+    path = os.path.abspath(string)
+    if not path.endswith(".yaml") and not path.endswith(".yml"):
+        raise argparse.ArgumentTypeError("Must be a .yaml file {}".format(path))
+    return readable_file(string)
+
+def make_boolean_checkers(func):
+    fn_name = f"is_{func.__name__}"
+    thismodule = sys.modules[__name__]
+    def fn(string):
+        try:
+            func(string)
+        except Exception as e:
+            logger.error(e)
+            return False
+        return True
+    setattr(thismodule, fn_name, fn)
+
+fn_list = [
+    positive_int,
+    non_negative_int,
+    unit_interval,
+    readable_file,
+    readable_yaml_file
+]
+for elem in fn_list:
+    make_boolean_checkers(elem)

--- a/glyph/utils/argparse.py
+++ b/glyph/utils/argparse.py
@@ -7,6 +7,7 @@ import argparse
 import logging
 import os
 import sys
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,16 @@ def readable_yaml_file(string):
         raise argparse.ArgumentTypeError("Must be a .yaml file {}".format(path))
     return readable_file(string)
 
+def np_infinity_int(string):
+    if string == str(np.infty):
+        return np.infty
+    else:
+        try:
+            value = int(string, base=10)
+        except ValueError:
+            raise argparse.ArgumentTypeError("invalid int value: '{}'".format(string))
+        return value
+
 def make_boolean_checkers(func):
     fn_name = f"is_{func.__name__}"
     thismodule = sys.modules[__name__]
@@ -90,7 +101,8 @@ fn_list = [
     non_negative_int,
     unit_interval,
     readable_file,
-    readable_yaml_file
+    readable_yaml_file,
+    np_infinity_int
 ]
 for elem in fn_list:
     make_boolean_checkers(elem)

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,0 +1,2 @@
+wxpython==4.0.3
+gooey==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,15 @@ AUTHOR = "Markus Abel, Julien Gout, Markus Quade"
 KEYWORDS = "complex systems, control, machine learning, genetic programming"
 LICENCE = "LGPL"
 PYTHON = ">=3.5"
+DEPENDENCY_LINKS = ["git+https://github.com/Magnati/Gooey.git#egg=gooey-1.0.0"]
 
 here = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(here, "requirements.txt"), "r") as f:
     REQUIRED = f.readlines()
+
+with open(os.path.join(here, "requirements-gui.txt"), "r") as f:
+    REQUIRED_GUI = f.readlines()
 
 with open(os.path.join(here, "README.md"), "r") as f:
     LONG_DESCRIPTION = f.read()
@@ -45,6 +49,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
         ],
+        extras_require={"gui": REQUIRED_GUI},
         entry_points={
             "console_scripts": [
                 "glyph-remote = glyph.cli.glyph_remote:main"


### PR DESCRIPTION
Gooey UI for glyph
- new `--gui` prameter activates a Gooey based UI ([Magnati/Gooey](https://github.com/Magnati/Gooey) beause PR was not accepted till now)
- `glyph_gooey.py` in new directory `glyph/gui` to get GooeyParser if needed.
- `experiment-gui.py` is **in progress**
- some parameters needed to be changed, to make the Gooey handling possible on one side, but remain the shell functionality on the other (esspecially verbosity needed a workaround) 
- new wrappeer functions for the value checker methods to enhance gui functionality in `glyph/utils/argparse.py`

Argparsechanges in glyph_remote:<br>
The goal was to make it possible to set some parameters already in the shell which are then set in the gui. For that to happen some paramater-declarations had to be changed.
- `type=bool` are a problem for Gooey: all parameters of type `bool` I replaced with the appropriate `action=store_false` or `store_true`, like that the behaviour is okay.
- `max_iter_total` and inf: the type was int, but 'inf' was a valid input. To make that possible I changed the type to the `utils.argparse.np_infinity_int` Like that it works.
- `verbosity` is a count variable which caused a lot of trouble. The solution now is still not satisfying, but the best nearing I could get for the overall goal: In the shell it is still possible to use -vvv BUT the first v is not counted, but is the parameter identifier ( `-vv = lv 1`). Later in the code the len(arg-string) is translated to logger level.  

